### PR TITLE
Allow setting `solver`

### DIFF
--- a/src/troppo/methods/base.py
+++ b/src/troppo/methods/base.py
@@ -14,7 +14,7 @@ class ContextSpecificModelReconstructionAlgorithm(object):
 	__metaclass__ = abc.ABCMeta
 
 	@abc.abstractmethod
-	def __init__(self, S, lb, ub, properties):
+	def __init__(self, S, lb, ub, properties, solver):
 		pass
 
 	@abc.abstractmethod

--- a/src/troppo/methods/base.py
+++ b/src/troppo/methods/base.py
@@ -14,7 +14,7 @@ class ContextSpecificModelReconstructionAlgorithm(object):
 	__metaclass__ = abc.ABCMeta
 
 	@abc.abstractmethod
-	def __init__(self, S, lb, ub, properties, solver):
+	def __init__(self, S, lb, ub, properties):
 		pass
 
 	@abc.abstractmethod

--- a/src/troppo/methods/reconstruction/imat.py
+++ b/src/troppo/methods/reconstruction/imat.py
@@ -26,7 +26,7 @@ class IMATProperties(PropertiesReconstruction):
         The epsilon, by default 1
     """
     def __init__(self, exp_vector: np.ndarray or list, exp_thresholds: tuple or list or ndarray,
-                 core: ndarray or list or tuple = None, tolerance: float = 1e-8, epsilon: int or float = 1):
+                 core: ndarray or list or tuple = None, tolerance: float = 1e-8, epsilon: int or float = 1, solver: str = None):
         new_mandatory = {
             'exp_vector': lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
             'exp_thresholds': lambda x: type(x) in (tuple, list, ndarray) and type(x[0]) in [float, int] and type(
@@ -49,6 +49,8 @@ class IMATProperties(PropertiesReconstruction):
             self['tolerance'] = tolerance
         if epsilon:
             self['epsilon'] = epsilon
+        if solver:
+            self["solver"] = solver
 
     @staticmethod
     def from_integrated_scores(scores: list, **kwargs) -> 'IMATProperties':
@@ -213,7 +215,7 @@ class IMAT(ContextSpecificModelReconstructionAlgorithm):
         prefix_maker = lambda cd: list([cd[0] + str(i) for i in range(cd[1])])
         A_names = list(chain(*list(map(prefix_maker, [('V', n), ('Hpos', nh), ('Hneg', nh), ('L', nl)]))))
 
-        lsystem = GenericLinearSystem(S=A, var_types=A_vt, lb=A_lb, ub=A_ub, b_lb=b_lb, b_ub=b_ub, var_names=A_names)
+        lsystem = GenericLinearSystem(S=A, var_types=A_vt, lb=A_lb, ub=A_ub, b_lb=b_lb, b_ub=b_ub, var_names=A_names, solver=self.properties["solver"])
         lso = LinearSystemOptimizer(lsystem)
 
         A_f = np.zeros((A.shape[1]))

--- a/src/troppo/methods/reconstruction/imat.py
+++ b/src/troppo/methods/reconstruction/imat.py
@@ -30,7 +30,8 @@ class IMATProperties(PropertiesReconstruction):
         new_mandatory = {
             'exp_vector': lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
             'exp_thresholds': lambda x: type(x) in (tuple, list, ndarray) and type(x[0]) in [float, int] and type(
-                x[1]) in [float, int]
+                x[1]) in [float, int],
+            "solver": solver
         }
         new_optional = {
             'core': lambda x: type(x) in [ndarray, list, tuple],
@@ -49,8 +50,6 @@ class IMATProperties(PropertiesReconstruction):
             self['tolerance'] = tolerance
         if epsilon:
             self['epsilon'] = epsilon
-        if solver:
-            self["solver"] = solver
 
     @staticmethod
     def from_integrated_scores(scores: list, **kwargs) -> 'IMATProperties':


### PR DESCRIPTION
Allow setting a `solver` in iMAT that trickles down to cobamp